### PR TITLE
Implement persistent high score tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
           <div class="label">Leaderboard</div>
           <div class="lb-list" id="leaderboardList"></div>
           <div class="lb-controls">
+            <button class="btn ghost" id="openHighScores">High Scores</button>
             <button class="btn ghost" id="exportLb">Export</button>
             <button class="btn ghost" id="shareLb">Share</button>
             <button class="btn ghost" id="clearLb">Clear</button>
@@ -133,6 +134,20 @@
       <div style="display:flex;gap:0.6rem;margin-top:1rem;justify-content:flex-end">
         <button class="btn ghost" id="closeModal">Close</button>
         <button class="btn" id="playAgain">Play Again</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- High Scores Modal -->
+  <div class="modal-overlay" id="highScoresOverlay" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-box" role="document">
+      <h2>High Scores</h2>
+      <div class="subtitle">Best records per difficulty</div>
+      <div class="modal-stats" style="display:block">
+        <div id="highScoresContainer"></div>
+      </div>
+      <div style="display:flex;gap:0.6rem;margin-top:1rem;justify-content:flex-end">
+        <button class="btn ghost" id="closeHighScores">Close</button>
       </div>
     </div>
   </div>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -386,6 +386,21 @@ h1.title {
   margin: 0 0 0.6rem;
 }
 
+/* High Scores table styles (inherits Pip-Boy theme) */
+#highScoresContainer table th,
+#highScoresContainer table td {
+  padding: 8px 10px;
+}
+#highScoresContainer table thead th {
+  color: var(--vault-yellow);
+  font-family: 'Share Tech Mono', monospace;
+  font-weight: 700;
+}
+#highScoresContainer table tbody tr td {
+  background: rgba(255,255,255,0.02);
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+
 .modal-stats {
   display: flex;
   gap: 1rem;


### PR DESCRIPTION
This PR fixes #9 by adding a localStorage-based high score system that tracks and displays per-difficulty best records:
Best time (per difficulty)
Best move count (per difficulty)
Best star rating (per difficulty)
Dedicated “High Scores” modal to view all records

Higher stars beats lower stars
If stars equal, fewer moves wins
If stars and moves equal, faster time wins

![High Scores demo](https://github.com/user-attachments/assets/300c376d-bfb4-45ec-b4c9-0f769d3084c8)

![Gameplay grid](https://github.com/user-attachments/assets/2507cfb7-1c19-44af-9e66-0aac339c33bd)

