### PR TITLE
Add Move Count Limit for Extra Challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,16 @@
           </div>
         </div>
 
+        <div style="margin-top:0.8rem;display:flex;align-items:center;gap:0.4rem">
+          <label for="move-limit-toggle">
+            <input type="checkbox" id="move-limit-toggle" />
+            Enable Move Limit
+          </label>
+        </div>
+        <div id="move-limit-display" style="display:none ;margin-top:0.4rem;color:var(--muted);font-size:0.9rem">
+          Moves: <span id="remaining-moves"></span> remaining
+        </div>
+
         <div class="controls">
           <button class="btn" id="restart">Restart</button>
           <button class="btn ghost" id="hint">Reveal 1 Pair</button>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -412,6 +412,7 @@ h1.title {
   align-items: center;
   justify-content: center;
   z-index: 30;
+  left: 320px; 
 }
 
 .modal-box {


### PR DESCRIPTION
[ADD] add the move count limit feature for the all level and update the logic accordingly

- Add the Enable Move Limit checkbox
- Add the remaining moves (Moves for level: - Easy: 30, Medium: 25, Hard: 20)
- Stop the game and show the modal popup when the remaining moves are <= 0 

ISSUE:  #44 

**Screenshot for the updated feature:**
<img width="1294" height="691" alt="Screenshot from 2025-10-16 16-27-55" src="https://github.com/user-attachments/assets/bd555120-ff03-4da8-b902-13d321bfa4fc" />

**Modal with reason:**
<img width="1294" height="691" alt="Screenshot from 2025-10-16 16-32-26" src="https://github.com/user-attachments/assets/d150cd10-0d29-40c8-973b-8a92866bc323" />
