### PR TITLE
improved spacing and layout balance between score panel and game grid (#51)

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -60,8 +60,9 @@ body {
   margin: 0 auto;
   display: grid;
   grid-template-columns: 320px 1fr;
-  gap: 2rem;
+  gap: 8rem; /* clear separation */
   align-items: start;
+   justify-content: center; /*neat alignment */
 }
 
 .panel {
@@ -737,5 +738,18 @@ h1.title {
     font-size: 0.8rem;
     flex-direction: column;
     gap: 0.3rem;
+  }
+}
+/* Responsive layout adjustments */
+@media (max-width: 1400px) {
+  .app {
+    gap: 5rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .app {
+    gap: 3rem;
+    grid-template-columns: 1fr; /* stack panel on top */
   }
 }


### PR DESCRIPTION
closes #51 
### Overview:
This PR enhances the visual layout of the Memory Game interface by improving the spacing between the score panel and the game grid. The previous layout appeared cramped, especially on larger screens, making the UI feel unbalanced.

### Changes Made:
Adjusted .app layout grid with a balanced gap for consistent spacing between the score panel and game grid.
Center-aligned the main layout using justify-content: center for a clean and cohesive visual structure.
Added responsive design tweaks:
Reduced gap for medium screens (max-width: 1400px → gap: 5rem)
Stacked layout for smaller screens (max-width: 1024px) to maintain readability.

merge this under **hacktoberfest** labels

Please let me know if any further adjustments are needed — happy to refine it as per feedback! 😊
