### PR TITLE
added logo instead of text VT in the footer to enhance the overall UI #52

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
     <footer class="footer">
       <div class="footer-content">
         <div class="footer-brand">
-          <div class="vault-badge vault-badge--small">VT</div>
+          <div class="vault-badge vault-badge--small"><img src="img/LogoMain.png"></div>
           <span>Vault-Tec Memory Trainer | Pip-Boy Edition</span>
         </div>
         <div class="footer-info">


### PR DESCRIPTION
closes #52 
replaced the text “VT” as a placeholder next to the project title (“Vault-Tec Memory Trainer | Pip-Boy Edition”) with the Vault-Tec logo image, aligning visually with the overall Vault-Tec theme.

before : 
<img width="1919" height="320" alt="image" src="https://github.com/user-attachments/assets/26a9451e-dc6f-48af-b6f5-aba4d7d99822" />

after : 
<img width="1910" height="545" alt="image" src="https://github.com/user-attachments/assets/95c7c5f4-2482-41da-9824-716d58b4ac59" />

merge this under hacktoberfest labels

Please let me know if any further adjustments are needed — happy to refine it as per feedback! 😊

